### PR TITLE
docs: small fix to summary argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ dyana trace ... --allow-network
 Show a summary of the trace file with:
 
 ```bash
-dyana summary --trace trace.json
+dyana summary --trace-path trace.json
 ```
 
 ## License


### PR DESCRIPTION
very small argument fix in README, ie:

```bash
(dyana-cli-py3.12) ➜  dyana git:(docs/small-readme-fixes) ✗ dyana summary -h
                                                                                                             
 Usage: dyana summary [OPTIONS]                                                                              
                                                                                                             
 Show a summary of the trace.                                                                                
                                                                                                             
╭─ Options ─────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --trace-path          PATH  Path to the trace file. [default: trace.json]                                 │
│ --help        -h            Show this message and exit.                                                   │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────╯

(dyana-cli-py3.12) ➜  dyana git:(docs/small-readme-fixes) ✗ dyana summary --trace trace.json
Usage: dyana summary [OPTIONS]
Try 'dyana summary -h' for help.
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────────────────╮
│ No such option: --trace Did you mean --trace-path? 
```