### PR TITLE
chore: suggested additional docker params

### DIFF
--- a/dyana_cli/loaders/docker.py
+++ b/dyana_cli/loaders/docker.py
@@ -128,7 +128,6 @@ def run_detached(
             docker.types.Ulimit(name="nofile", soft=1024, hard=1024),
             docker.types.Ulimit(name="nproc", soft=100, hard=100),
         ],
-        userns_mode="host",
         ipc_mode="none",
     )
 


### PR DESCRIPTION
### intro

**objective**: introduce arguments that the [`.run` function accepts](https://github.com/dreadnode/dyana/blob/main/dyana_cli/loaders/docker.py#L103) to enforce more strict security without impacting the loaders functionally

some related docs: (mainly looking at CIS benchmarks and [runtime constraints](https://docs.docker.com/engine/containers/run/)) for the reason of this proposed change

- https://github.com/docker/docker-bench-security
- https://docs.datadoghq.com/security/default_rules/cis-docker-1.2.0-5.20/
- https://docs.docker.com/engine/security/userns-remap/

-----

completely optional changes proposed tldr;

```python
    # Security Settings
    security_opt=[
        "no-new-privileges",    # Prevent privilege escalation
        "seccomp=unconfined",   # Allow required syscalls for ML
    ],
    cap_drop=["ALL"],          # Drop all Linux capabilities
    
    # Resource Limits
    tmpfs={"/tmp": "size=100m,noexec"},  # Secure temp storage
    pids_limit=100,            # Prevent fork bombs
    
    # File/Process Limits
    ulimits=[
        docker.types.Ulimit(name="nofile", soft=1024, hard=1024),  # Max open files
        docker.types.Ulimit(name="nproc", soft=100, hard=100),     # Max processes
    ],
    
    # Namespace Isolation
    ipc_mode="none",          # Disable IPC
```

**optional thought**: perhaps CLI parameters for memory and cpu limitations with a default? since there's use-cases for both (ie big models, small models, scripts etc), then ie: (would also need to update `README` usage and `-h`)
```python
    mem_limit="16g",
    cpu_quota=400000,
```

### testing:

may require some more testing, i mainly used the `README` usage examples as a baseline

```bash
(dyana-cli-py3.12) ➜  dyana git:(chore/docker-isolation-parameter-suggestions) ✗ dyana trace --model $(pwd)/bert-base-japanese --input "This is an example sentence." --extra-requirements "protobuf fugashi ipadic"
..
Successfully tagged dyana-automodel-loader:latest
🐳 loader: using image dyana-automodel-loader:latest (sha256:a51eaac8001f19d8bb1654b7ca67901bedf326245c30466a2d8a39d876c20076)
👁️‍🗨️  tracer: initializing ...
👁️‍🗨️  tracer: started ...
🍿 loader: executing with arguments ['--model', '/bert-base-japanese', '--input', 'This is an example sentence.'] ...
👁️‍🗨️  tracer: stopping ...
🗃  saving 6036 events to trace.json

Platform       : macOS-15.2-arm64-arm-64bit
Loader         : automodel
Build args     : EXTRA_REQUIREMENTS=protobuf fugashi ipadic
Arguments      : --model /bert-base-japanese --input This is an example sentence.
Volumes        : /bert-base-japanese (/Users/ads/git/dyana/bert-base-japanese)
Started at     : 2025-01-07T13:38:57.090991
Ended at       : 2025-01-07T13:39:00.827430
Total Events   : 6036

RAM:
  * start : 222.4MiB
  * after_tokenizer_loaded : 236.7MiB 🔺 14.3MiB
  * after_tokenization : 236.7MiB
  * after_model_loaded : 849.8MiB 🔺 613.1MiB
  * after_model_inference : 849.8MiB

Process Executions:
  * python3 -> execve /usr/local/bin/python3 ['python3', '-W', 'ignore', 'main.py', '--model', '/bert-base-japanese', '--input', 'This is an example 
sentence.']

File Accesses:
  * /app
  * /app/main.py
  * /bert-base-japanese/config.json
  * /bert-base-japanese/pytorch_model.bin
  * /bert-base-japanese/tokenizer_config.json
  * /bert-base-japanese/vocab.txt
  * /docker/overlay2/9a439e84ea197e47cdb5f75802c5869d29fdf80c896d60aa4a361ca105ce3a01/work/work/#8a7
  * /docker/overlay2/9a439e84ea197e47cdb5f75802c5869d29fdf80c896d60aa4a361ca105ce3a01/work/work/#8a8
  * /root/.cache/huggingface/hub/version.txt

  * 5875 accesses to /usr/local/lib/*
  * 6 accesses to /usr/lib/*
  * 30 accesses to /lib/*
  * 1 accesses to /dev/*
  * 3 accesses to /proc/*
  * 60 accesses to /sys/*
  * 20 accesses to /etc/*
```

```bash
(dyana-cli-py3.12) ➜  dyana git:(chore/docker-isolation-parameter-suggestions) ✗ dyana trace --loader pickle --pickle malicious.pickle
..
👁️‍🗨️  tracer: stopping ...
🗃  saving 314 events to trace.json

Platform       : macOS-15.2-arm64-arm-64bit
Loader         : pickle
Arguments      : --pickle /malicious.pickle
Volumes        : /malicious.pickle (/Users/ads/git/dyana/malicious.pickle)
Started at     : 2025-01-07T13:55:58.093462
Ended at       : 2025-01-07T13:55:59.227265
Total Events   : 314

RAM:
  * start : 16.8MiB
  * after_load : 16.9MiB 🔺 128.0KiB

Process Executions:
  * python3 -> execve /usr/local/bin/python3 ['python3', '-W', 'ignore', 'main.py', '--pickle', '/malicious.pickle']
  * sh -> execve /bin/sh ['sh', '-c', 'touch /tmp/pwned && cat /etc/passwd']
  * touch -> execve /usr/bin/touch ['touch', '/tmp/pwned']
  * cat -> execve /usr/bin/cat ['cat', '/etc/passwd']

File Accesses:
  * /app
  * /app/main.py
  * /bin/sh
  * /malicious.pickle
  * /tmp/pwned
  * /usr/bin/cat
  * /usr/bin/touch

  * 191 accesses to /usr/local/lib/*
  * 60 accesses to /usr/lib/*
  * 18 accesses to /lib/*
  * 18 accesses to /etc/*
```

```bash
(dyana-cli-py3.12) ➜  dyana git:(chore/docker-isolation-parameter-suggestions) ✗ dyana trace --loader python --script examples/hello.py
🐳 loader: using image dyana-python-loader:latest (sha256:75afa519889dfa3aa40b64031b2a5ff7ad0cf03150920efafcf267a12744634c)
👁️‍🗨️  tracer: initializing ...
👁️‍🗨️  tracer: started ...
🍿 loader: executing with arguments ['--script', '/hello.py'] ...
👁️‍🗨️  tracer: stopping ...
🗃  saving 205 events to trace.json

Platform       : macOS-15.2-arm64-arm-64bit
Loader         : python
Arguments      : --script /hello.py
Volumes        : /hello.py (/Users/ads/git/dyana/examples/hello.py)
Started at     : 2025-01-07T13:52:28.802573
Ended at       : 2025-01-07T13:52:29.944696
Total Events   : 205
Stdout         : Hello World!
Stderr         : This is going to stderr!
Exit code      : 42

RAM:
  * start : 11.5MiB
  * after_execution : 11.5MiB

Process Executions:
  * python3 -> execve /usr/local/bin/python3 ['python3', '-W', 'ignore', 'main.py', '--script', '/hello.py']
  * python -> execve /usr/local/bin/python ['python', '/hello.py']

File Accesses:
  * /app
  * /app/main.py
  * /hello.py
  * /usr/local/bin/python

  * 146 accesses to /usr/local/lib/*
  * 8 accesses to /usr/lib/*
  * 18 accesses to /lib/*
  * 14 accesses to /etc/*
```

(fyi: error is unrelated and is to do with usage of `exec` in the loader combined with the example js script i believe)

```bash
(dyana-cli-py3.12) ➜  dyana git:(chore/docker-isolation-parameter-suggestions) ✗ dyana trace --loader js --script examples/hello.js
👁️‍🗨️  tracer: initializing ...
👁️‍🗨️  tracer: started ...
🍿 loader: executing with arguments ['--script', '/hello.js'] ...
👁️‍🗨️  tracer: stopping ...
🗃  saving 67 events to trace.json

Platform       : macOS-15.2-arm64-arm-64bit
Loader         : js
Arguments      : --script /hello.js
Volumes        : /hello.js (/Users/ads/git/dyana/examples/hello.js)
Started at     : 2025-01-07T13:51:21.268288
Ended at       : 2025-01-07T13:51:22.407879
Total Events   : 67

Errors:

  * js: Command failed: node /hello.js
This is going to stderr!


Stdout         : Hello World!
Stderr         : This is going to stderr!
Exit code      : 42

RAM:
  * start : 44.7MiB
  * after_execution : 45.6MiB 🔺 828.0KiB

Process Executions:
  * node -> execve /usr/local/bin/node ['node', 'main.js', '--script', '/hello.js']
  * sh -> execve /bin/sh ['/bin/sh', '-c', 'node /hello.js']
  * node -> execve /usr/local/bin/node ['node', '/hello.js']

File Accesses:
  * /app/main.js
  * /bin/sh
  * /hello.js
  * /usr/local/bin/node

  * 26 accesses to /lib/*
  * 4 accesses to /dev/*
  * 6 accesses to /proc/*
  * 4 accesses to /sys/*
  * 6 accesses to /etc/*
```