### PR TITLE
Loaders/improve pip loader package name detection

### DIFF
--- a/dyana/loaders/pip/main.py
+++ b/dyana/loaders/pip/main.py
@@ -6,11 +6,12 @@ import os
 import re
 import subprocess
 import sys
+from typing import Any
 
 from dyana import Profiler  # type: ignore[attr-defined]
 
 
-def find_site_packages():
+def find_site_packages() -> str | None:
     """Find the site-packages directory where pip installs packages."""
     for path in sys.path:
         if path.endswith("site-packages"):
@@ -30,12 +31,12 @@ def debug_package_metadata(package_name: str, profiler: Profiler) -> None:
     egg_info = list(glob.glob(os.path.join(site_packages, f"{package_name}*.egg-info")))
     package_files = list(glob.glob(os.path.join(site_packages, f"{package_name}*")))
 
-    debug_info = {
+    debug_info: dict[str, Any] = {
         "site_packages": site_packages,
         "dist_info_found": dist_info,
         "egg_info_found": egg_info,
         "package_files": package_files,
-        "top_level_contents": {},
+        "top_level_contents": dict[str, str](),
     }
 
     # check top_level.txt

--- a/test_pip_loader.sh
+++ b/test_pip_loader.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+PACKAGES=(
+    "aims-chain"
+    "visualdsa"
+    "masterzdran-azure-tablestorge-logging"
+    "inchatvx"
+    "llmcode-chat"
+    "aiman-client"
+    "unique-linear-solver"
+    "clix-bshg"
+    "input-logger"
+    "upfilelive"
+    "yudkow-models"
+    "mvent"
+    "tcmath"
+    "srtranslator-bariskeser"
+    "js2py2"
+)
+
+for pkg in "${PACKAGES[@]}"; do
+    echo "Testing package: $pkg"
+    dyana trace --loader pip --package "$pkg" > "test_results/${pkg}.json" 2>&1
+    echo "Completed testing package: $pkg"
+    echo "----------------------------------------"
+done


### PR DESCRIPTION
closes #29

## Problem
as well pointed out from evilsocket in the github issue, the PIP loader had issues detecting correct import names for packages where: (due to package name management being a huge pain with a lack of publishing constraints)
- the import name differed from package name (e.g., `aims-chain` → `aimsChain`)
- package metadata files contained the actual import names
- case-sensitive

## Solution 🤞 

performing some validation and follow-up testing but here is the initial PoC
my testing criteria is as follows: (also created a simple bash script temporarily to test this)

Basic package name normalization:
```bash
dyana trace --loader pip --package aims-chain
dyana trace --loader pip --package visualdsa
dyana trace --loader pip --package inchatvx
dyana trace --loader pip --package tcmath
dyana trace --loader pip --package js2py2
```
Complex package names with multiple hyphens:
```bash
dyana trace --loader pip --package masterzdran-azure-tablestorge-logging
dyana trace --loader pip --package llmcode-chat
dyana trace --loader pip --package unique-linear-solver
dyana trace --loader pip --package clix-bshg
dyana trace --loader pip --package input-logger
dyana trace --loader pip --package srtranslator-bariskeser
```
Packages with potential submodules:
```bash
dyana trace --loader pip --package mvent  # tries to import mvent.decorators
dyana trace --loader pip --package aiman-client
```
Packages with different import names:
```bash
dyana trace --loader pip --package yudkow-models  # imports as 'transformers'
dyana trace --loader pip --package upfilelive
```

re: the package name variations, to provide context of the changes introduced with our inline example:

```python
    # Look for variations of the package name
    base_name = package_name.replace("-", "_")
    variations = [
        package_name,  # original: aims-chain
        base_name,  # underscored: aims_chain
        base_name.lower(),  # lowercase: aims_chain
        base_name.title(),  # title case: Aims_Chain
        base_name.replace("_", ""),  # no separator: aimschain
        "".join(w.capitalize() for w in base_name.split("_")),  # camelCase: aimsChain
        "".join(w.capitalize() for w in package_name.split("-")),  # camelCase from hyphen: aimsChain
    ]
```

example output so far: `dyana trace --loader pip --package aims-chain` example:

<details>
  <summary>expand/collapse</summary>

```bash
(dyana-cli-py3.12) ➜  dyana git:(loaders/improve-pip-loader-package-name-detection) ✗ dyana trace --loader pip --package aims-chain              

🐳 loader: initializing loader pip
👁️‍🗨️  tracer: initializing ...
👁️‍🗨️  tracer: started ...
🍿 loader: required bridged network access
🍿 loader: executing with arguments ['--package', 'aims-chain'] ...
👁️‍🗨️  tracer: stopping ...
🗃  saving 12381 events to trace.json

Platform       : macOS-15.2-arm64-arm-64bit
Loader         : pip
Arguments      : --package aims-chain
Started at     : 2025-01-21T16:35:47.631338
Ended at       : 2025-01-21T16:35:57.038954
Total Events   : 12381
Stdout         : Collecting aims-chain
  Downloading aims_chain-0.1.0-py3-none-any.whl.metadata (4.8 kB)
Collecting numpy (from aims-chain)
  Downloading numpy-2.2.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl.metadata (63 kB)
Collecting scipy (from aims-chain)
  Downloading scipy-1.15.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl.metadata (115 kB)
Downloading aims_chain-0.1.0-py3-none-any.whl (42 kB)
Downloading numpy-2.2.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (14.0 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 14.0/14.0 MB 35.1 MB/s eta 0:00:00
Downloading scipy-1.15.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (38.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 38.1/38.1 MB 22.9 MB/s eta 0:00:00
Installing collected packages: numpy, scipy, aims-chain
Successfully installed aims-chain-0.1.0 numpy-2.2.2 scipy-1.15.1

Attempting imports with names: ['aimsChain', 'aimsChain.tools.runchain', 'aims_chain']


Successfully imported as 'aimsChain'

RAM:
  * start : 12.5MiB
  * after_installation : 12.5MiB

Disk Usage:
  * start : 37.0GiB
  * after_installation : 37.3GiB 🔺 324.9MiB

Process Executions:
* 1 python3 -> execve /usr/local/bin/python3 ['python3', '-W', 'ignore', 'main.py', '--package', 'aims-chain']
  * 7 python3 -> execve /usr/local/bin/python3 ['/usr/local/bin/python3', '-m', 'pip', 'install', '--no-cache-dir', '--root-user-action=ignore', 'aims-chain']
    * 9 uname -> execve /usr/bin/uname ['uname', '-rs']

Network Usage:
  eth0
    start : rx=410.0B tx=0.0B
    end : rx=50.7MiB 🔺 50.7MiB tx=80.2KiB 🔺 80.2KiB

Network Activity:
  * [7] python3 -> connect /var/run/nscd/socket
  * [7] python3 -> connect 192.168.65.7:53
  * [7] python3 | dns | question=pypi.org
  * [159] init | dns | answer=pypi.org=2a04:4e42:400::223, pypi.org=2a04:4e42:200::223, pypi.org=2a04:4e42::223, pypi.org=2a04:4e42:600::223
  * [159] init | dns | answer=pypi.org=151.101.0.223, pypi.org=151.101.192.223, pypi.org=151.101.128.223, pypi.org=151.101.64.223
  * [7] python3 -> connect [2a04:4e42:400::223]:443
  * [7] python3 -> connect [2a04:4e42:200::223]:443
  * [7] python3 -> connect [2a04:4e42::223]:443
  * [7] python3 -> connect [2a04:4e42:600::223]:443
  * [7] python3 -> connect 151.101.0.223:443
  * [7] python3 -> connect 151.101.192.223:443
  * [7] python3 -> connect 151.101.128.223:443
  * [7] python3 -> connect 151.101.64.223:443
  * [7] python3 | dns | question=files.pythonhosted.org
  * [159] init | dns | answer=files.pythonhosted.org=, dualstack.python.map.fastly.net=151.101.124.223
  * [159] init | dns | answer=files.pythonhosted.org=, dualstack.python.map.fastly.net=2a04:4e42:1e::223
  * [7] python3 -> connect 151.101.124.223:443
  * [7] python3 -> connect [2a04:4e42:1e::223]:443

File Accesses:
  * /app
  * /app/__pycache__/dyana.cpython-312.pyc.281472861197120
  * /app/dyana.py
  * /app/main.py
  * /docker/overlay2/079a3f1b755a7dc84f636539ccf5ab9f51731445dde18412676eb214238736dc/work/work/#1118
  * /etc
  * /usr/bin/uname
  * /usr/local/bin/f2py
  * /usr/local/bin/numpy-config
  * /usr/local/bin/python3
  * /usr/local/bin/runchain

  * 11905 accesses to /usr/local/lib/*
  * 78 accesses to /usr/lib/*
  * 32 accesses to /lib/*
  * 2 accesses to /dev/*
  * 2 accesses to /proc/*
  * 42 accesses to /etc/*
  * 53 accesses to /tmp/*

Security Events:
  * New executable dropped (defense-evasion, moderate severity)

Top Level Imports: 
  * importlib.*: 16
  * email.*: 13
  * zipfile.*: 3
  * urllib.*: 2
  * _csv
  * csv
  * ntpath
  * ipaddress
  * pathlib
  * binascii
  * _struct
  * struct
  * textwrap
  * _ast
  * ast
  * _opcode
  * opcode
  * dis
  * token
  * _tokenize
  * tokenize
  * linecache
  * weakref
  * inspect
  * quopri
  * _bisect
  * bisect
  * _random
  * _sha2
  * random
  * _socket
  * array
  * socket
  * _datetime
  * datetime
  * calendar
  * base64
  * _string
  * string
  * tempfile
  * aimsChain
```

</details>

## going forward

performing more validation and testing prior to marking this ready for review