### PR TITLE
Fix potential errors related to invoking decode on str object

### DIFF
--- a/dyana/tracer/tracee.py
+++ b/dyana/tracer/tracee.py
@@ -131,7 +131,8 @@ class Tracer:
             # https://github.com/docker/docker-py/issues/2913
             for char in logs:
                 try:
-                    char = char.decode("utf-8")
+                    if not isinstance(char, str):
+                        char = char.decode("utf-8")
                 except UnicodeDecodeError:
                     char = char.decode("utf-8", errors="replace")
 


### PR DESCRIPTION
Hi,

I was testing the tool on my laptop (macOS Sonoma 14.7.2, Python 3.13.1) and I noticed that by simply running a scan as shown in the example, e.g. `dyana trace --loader pip --package botocore` I was getting the following error:

```
File "[REDACTED]/.venv/lib/python3.13/site-packages/dyana/tracer/tracee.py", line 128, in _reader_thread
    char = char.decode("utf-8")
           ^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```

By modifying the code as in the PR fixed the AttributeError.