### PR TITLE
fix: fix docs hyperlink in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Dyana
 
+<div align="center">
+
+<img
+  src="https://d1lppblt9t2x15.cloudfront.net/logos/5714928f3cdc09503751580cffbe8d02.png"
+  alt="Logo"
+  align="center"
+  width="144px"
+  height="144px"
+/>
+
+</div>
+
 <h4 align="center">
     <a href="https://pypi.org/project/dyana/" target="_blank">
         <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/dyana">
@@ -11,9 +23,12 @@
     <a href="https://github.com/dreadnode/dyana/actions/workflows/ci.yml">
         <img alt="GitHub Actions Workflow Status" src="https://github.com/dreadnode/dyana/actions/workflows/ci.yml/badge.svg">
     </a>
+    <a href="https://github.com/dreadnode/dyana/actions/workflows/renovate.yaml/badge.svg">
+        <img alt="Renovate Status" src="https://github.com/dreadnode/dyana/actions/workflows/renovate.yaml">
+    </a>
 </h4>
 
-Dyana is a sandbox environment using Docker and [Tracee](https://github.com/aquasecurity/tracee) for loading, running and profiling a wide range of files, including machine learning models, ELF executables, Pickle serialized files, Javascripts [and more](https://docs.dreadnode.io/dyana/loaders/). It provides detailed insights into GPU memory usage, filesystem interactions, network requests, and security related events.
+Dyana is a sandbox environment using Docker and [Tracee](https://github.com/aquasecurity/tracee) for loading, running and profiling a wide range of files, including machine learning models, ELF executables, Pickle serialized files, Javascripts [and more](https://docs.dreadnode.io/open-source/dyana/topics/loaders). It provides detailed insights into GPU memory usage, filesystem interactions, network requests, and security related events.
 
 ## Installation
 


### PR DESCRIPTION
follow on from #46 

# fix docs hyperlink in readme

**Key Changes:**

- [ ] fixes broken hyperlink in readme

**Added:**

- [ ] added some standard image templating too

**Changed:**

- [ ] broken hyperlink in readme

i believe the renovate badge is blank as the workflow hasn't ran yet so i'll recheck this once it triggers before merging
---

## Generated Summary:

- Added a logo to the README for better visual representation.
- Introduced a badge for the Renovate status, improving visibility of dependency management.
- Updated the link for loaders documentation to reflect the correct URL.
- Minor formatting improvements and enhancements to the central alignment of content.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
