### PR TITLE
feat: mem_limit parameter for loaders when tracing

### DIFF
--- a/dyana/cli.py
+++ b/dyana/cli.py
@@ -97,6 +97,7 @@ def trace(
     no_gpu: bool = typer.Option(help="Do not use GPUs.", default=False),
     allow_network: bool = typer.Option(help="Allow network access to the model container.", default=False),
     allow_volume_write: bool = typer.Option(help="Mount volumes as read-write.", default=False),
+    mem_limit: str = typer.Option(help="Memory limit for /tmp directory (e.g. '100m', '1g').", default="100m"),
     verbose: bool = typer.Option(help="Verbose mode.", default=False),
 ) -> None:
     try:
@@ -109,7 +110,14 @@ def trace(
             raise typer.BadParameter(f"policy file or directory not found: {policy}")
 
         the_loader = Loader(
-            name=loader, timeout=timeout, platform=platform, args=ctx.args, verbose=verbose, save=save, save_to=save_to
+            name=loader,
+            timeout=timeout,
+            platform=platform,
+            args=ctx.args,
+            verbose=verbose,
+            save=save,
+            save_to=save_to,
+            mem_limit=mem_limit,
         )
         the_tracer = Tracer(the_loader, policy=policy)
 

--- a/dyana/docker.py
+++ b/dyana/docker.py
@@ -119,6 +119,7 @@ def run_detached(
     allow_network: bool = False,
     allow_gpus: bool = True,
     allow_volume_write: bool = False,
+    mem_limit: str = "100m",
 ) -> docker.models.containers.Container:
     _ensure_docker_client()
 
@@ -137,7 +138,7 @@ def run_detached(
     # enable GPUs
     device_requests = [docker.types.DeviceRequest(device_ids=["all"], capabilities=[["gpu"]])] if allow_gpus else None
 
-    # TODO: implement new command line arguments for limits such as : mem_limit="16g", cpu_quota=400000,
+    # TODO: implement new command line arguments for limits such as : cpu_quota=400000,
     return client.containers.run(
         image,
         command=command,
@@ -161,7 +162,9 @@ def run_detached(
             "seccomp=unconfined",
         ],
         cap_drop=["ALL"],
-        tmpfs={"/tmp": "size=100m,noexec"},
+        tmpfs={"/tmp": f"size={mem_limit},noexec"},
+        # Set overall memory limit for the container
+        mem_limit=mem_limit,
         # https://www.ibm.com/docs/en/wmlce/1.6.2?topic=frameworks-getting-started-pytorch#d15286e680
         pids_limit=16384,
         ulimits=[

--- a/dyana/loaders/loader.py
+++ b/dyana/loaders/loader.py
@@ -46,6 +46,7 @@ class Loader:
         save: list[str] | None = None,
         save_to: pathlib.Path = pathlib.Path("./artifacts"),
         verbose: bool = False,
+        mem_limit: str = "100m",
     ):
         # make sure that name does not include a path traversal
         if "/" in name or ".." in name:
@@ -81,6 +82,7 @@ class Loader:
         self.save: list[str] | None = save
         self.save_to: pathlib.Path = save_to.resolve().absolute()
         self.need_artifacts: bool = False
+        self.mem_limit = mem_limit
 
         if os.path.exists(self.settings_path):
             with open(self.settings_path) as f:
@@ -222,6 +224,7 @@ class Loader:
                 allow_network=allow_network,
                 allow_gpus=allow_gpus and (self.settings.gpu if self.settings else True),
                 allow_volume_write=allow_volume_write,
+                mem_limit=self.mem_limit,
             )
             self.container_id = self.container.id
             self.reader_thread = threading.Thread(target=self._reader_thread)


### PR DESCRIPTION
# feat: `mem_limit` parameter for loaders when tracing

**Key Changes:**

- [ ] closes #51
- [ ] adds an optional CLI parameter for `mem_limit` to assign to `tmp` for the docker image
- [ ] when no specific parameter is requested, 100m default (as per current code) is used

**Added:**

- [ ] adds an optional CLI parameter for `mem_limit` to assign to `tmp` for the docker image

**Changed:**

- [ ] updated `TODO`

**Removed:**

- [ ] na

---

a way of testing and validating this:

```bash
(dyana-cli-py3.12) ➜  dyana git:(main) ✗ dyana trace --loader pip --package docling --mem-limit 1m  
🐳 loader: initializing loader pip
👁️‍🗨️  tracer: initializing ...
👁️‍🗨️  tracer: started ...
🍿 loader: required bridged network access
🍿 loader: executing with arguments ['--package', 'docling'] ...
❌ error: 400 Client Error for http+docker://localhost/v1.47/containers/create: Bad Request ("Minimum memory limit allowed is 6MB")
(dyana-cli-py3.12) ➜  dyana git:(main) ✗ git checkout -b ads/eng-1381-dyana-feature-cli-parameter-for-docker-image-size-mem_limit
Switched to a new branch 'ads/eng-1381-dyana-feature-cli-parameter-for-docker-image-size-mem_limit'
```