### PR TITLE
fix: filename lowercase and add ignore paths

### DIFF
--- a/.github/renovate.JSON5
+++ b/.github/renovate.JSON5
@@ -48,5 +48,7 @@
       automergeType: "pr",
     },
   ],
-  ignorePaths: [],
+  ignorePaths: [
+    dyana/
+  ],
 }


### PR DESCRIPTION
# fix renovate workflows failing

**Key Changes:**

- [ ] updates `renovate.json5` to the correct filename (case sensitive)
- [ ] adds `ignore_path` to exclude the custom loaders requirements files

**Changed:**

- [ ] updates `renovate.json5` to the correct filename (case sensitive)
- [ ] adds `ignore_path` to exclude the custom loaders requirements files

---

## Generated Summary:

- Added a new entry to the `ignorePaths` in the Renovate configuration.
- The directory `dyana/` will now be ignored by Renovate, preventing it from attempting updates on this path.
- This change is aimed at simplifying dependency management by omitting the specified path from automated updates.
- No other configurations in Renovate have been altered.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
