### PR TITLE
fix: filename lowercase

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,6 +49,6 @@
     },
   ],
   ignorePaths: [
-    dyana/
+    "dyana/"
   ],
 }


### PR DESCRIPTION
# lowecase `renovate.json5` workflow fail fix

fix from #56 

**Key Changes:**

- [ ] had to remove this from tracking (`git rm --cached .github/renovate.JSON5`) which forced the git tracking to reflect the correct file

**Changed:**

- [ ] had to remove this from tracking (`git rm --cached .github/renovate.JSON5`) which forced the git tracking to reflect the correct file
- [ ] also fixed missing quote around `dyana` directory

---

## Generated Summary:

- Updated filename casing for consistency: renamed `renovate.JSON5` to `renovate.json5`.
- Modified the `ignorePaths` entry to ensure the path is enclosed in quotes: changed `dyana/` to `"dyana/"`.
- No functional changes were introduced; these adjustments enhance code readability and consistency.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
