### PR TITLE
fix: make cysimdjson optional for macOS/ARM compatibility

### DIFF
--- a/dyana/cli.py
+++ b/dyana/cli.py
@@ -1,8 +1,14 @@
+import json
 import pathlib
 import platform as platform_pkg
 
-# NOTE: json is too slow
-import cysimdjson
+try:
+    import cysimdjson
+
+    _HAS_CYSIMDJSON = True
+except ImportError:
+    _HAS_CYSIMDJSON = False
+
 import typer
 from rich import box
 from rich import print as rich_print
@@ -147,9 +153,11 @@ def trace(
 def summary(trace_path: pathlib.Path = typer.Option(help="Path to the trace file.", default="trace.json")) -> None:
     with open(trace_path) as f:
         raw = f.read()
-        # the standard json parser is too slow for this
-        parser = cysimdjson.JSONParser()
-        trace = parser.loads(raw)
+        if _HAS_CYSIMDJSON:
+            parser = cysimdjson.JSONParser()
+            trace = parser.loads(raw)
+        else:
+            trace = json.loads(raw)
 
     is_legacy: bool = "stages" not in trace["run"]
 

--- a/dyana/cli_test.py
+++ b/dyana/cli_test.py
@@ -1,24 +1,10 @@
 import json
 import re
-import sys
 import typing as t
-from unittest.mock import MagicMock
 
-# Mock cysimdjson before importing cli (not available on macOS ARM)
-_mock_cysimdjson = MagicMock()  # noqa: E402
+from typer.testing import CliRunner
 
-
-class _FakeJSONParser:
-    def loads(self, raw: str) -> t.Any:
-        return json.loads(raw)
-
-
-_mock_cysimdjson.JSONParser = _FakeJSONParser
-sys.modules.setdefault("cysimdjson", _mock_cysimdjson)
-
-from typer.testing import CliRunner  # noqa: E402
-
-from dyana.cli import cli  # noqa: E402
+from dyana.cli import cli
 
 runner = CliRunner()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -196,9 +196,10 @@ markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win
 name = "cysimdjson"
 version = "24.12"
 description = "High-speed JSON parser"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"fast-json\""
 files = [
     {file = "cysimdjson-24.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f1bca0c3a1b4be798266565b951fad85d38c386605af63928cda02ac28155cc"},
     {file = "cysimdjson-24.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d8c66262e6905a7c05c9663f5ef1176db292c4cf3091509ece2f4fee0218573"},
@@ -1218,7 +1219,10 @@ platformdirs = ">=3.9.1,<5"
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
+[extras]
+fast-json = ["cysimdjson"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "af45499c1aeee878ff47b72adea5ebab1367cb96cfb5ec6c2dbfabe93378a694"
+content-hash = "d5d02b620ded896caf93c92d1a16a9d44ad40f48096ef1efeac7d4aa58734eed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,11 @@ typer = "^0.16.0"
 pydantic = "^2.9.2"
 docker = "^7.1.0"
 rich = "^14.0.0"
-cysimdjson = "24.12"
+cysimdjson = {version = "24.12", optional = true}
 pydantic-yaml = "^1.4.0"
+
+[tool.poetry.extras]
+fast-json = ["cysimdjson"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

- `cysimdjson` only publishes `manylinux x86_64` wheels — `poetry install` fails on macOS ARM
- Make it an optional dependency behind a `fast-json` extra
- `cli.py` now gracefully falls back to stdlib `json` when `cysimdjson` is unavailable
- CI still gets `cysimdjson` via `--all-extras` on Linux
- Remove `sys.modules` mock hack from `cli_test.py` since the import is now handled cleanly

## Test plan

- [ ] `poetry install` succeeds on macOS ARM (no `--all-extras`)
- [ ] `poetry install --all-extras` succeeds on Linux x86_64 (CI)
- [ ] `dyana --help` works on macOS without cysimdjson
- [ ] `pytest dyana` — all 155 tests pass on all 3 Python versions
- [ ] `ruff check dyana` — lint clean
- [ ] `mypy` — type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Generated Summary:

- Updated the `cli.py` to conditionally import `cysimdjson`, allowing fallback to the standard `json` library if `cysimdjson` is not installed.
- Improved the performance of JSON parsing when `cysimdjson` is available.
- Modified the `summary` function to utilize `cysimdjson` if available, otherwise defaults to using `json.loads`.
- Adjusted `pyproject.toml` to mark `cysimdjson` as an optional dependency and added it to the `fast-json` extra.
- Removed unnecessary mocking of `cysimdjson` in tests, simplifying the test setup.
- These changes enhance the flexibility and performance of JSON parsing in different environments without compromising functionality for users without `cysimdjson`.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
