### PR TITLE
fix: fix invalid Renovate uv config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,9 +21,6 @@
   pep621: {
     fileMatch: ["pyproject.toml"],
   },
-  uv: {
-    fileMatch: ["pyproject.toml"],
-  },
   pip_requirements: {
     fileMatch: [
       "requirements-test.txt",
@@ -34,7 +31,7 @@
   },
   packageRules: [
     {
-      matchManagers: ["pep621", "uv", "pip_requirements"],
+      matchManagers: ["pep621", "pip_requirements"],
       matchPackagePatterns: ["^pytest"],
       groupName: "pytest packages",
       groupSlug: "pytest",


### PR DESCRIPTION

---

## Generated Summary:

- Removed the `uv` manager from the Renovate configuration.
- This change streamlines the package management by focusing on the `pep621` and `pip_requirements` managers.
- The update simplifies the configuration and may reduce unnecessary complexity in handling updates.
- It maintains existing functionality for `pytest` package grouping.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
